### PR TITLE
Add workout planner web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# codex-example
+# Exemple de programme de musculation
+
+Ce dépôt contient une simple page HTML permettant de créer et sauvegarder un programme de musculation pour chaque jour de la semaine.
+
+## Utilisation
+
+Ouvrez `index.html` dans votre navigateur. Les exercices peuvent se déplacer par glisser–déposer, et le programme se sauvegarde automatiquement dans le `localStorage` du navigateur. Il est possible d'exporter le programme du jour courant en PDF.
+
+Pour vérifier la validité du code HTML, vous pouvez utiliser l'outil `tidy` :
+
+```bash
+tidy -e index.html
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Programme de Musculation</title>
+<style>
+body {
+  font-family: Arial, sans-serif;
+  margin: 40px;
+  background: #f5f5f5;
+}
+h1 {
+  text-align: center;
+}
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 20px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  border-radius: 6px;
+}
+label {
+  display: block;
+  margin-top: 10px;
+}
+input,
+select {
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+button {
+  margin-top: 10px;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  background: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+button:hover {
+  background: #0056b3;
+}
+.exercise {
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-top: 10px;
+  background: #fafafa;
+  cursor: move;
+  border-radius: 4px;
+}
+.exercise:hover {
+  background: #f0f0f0;
+}
+.list {
+  min-height: 50px;
+}
+.day-selector {
+  margin-bottom: 20px;
+}
+</style>
+</head>
+<body>
+<div class="container">
+<h1>Programme de Musculation</h1>
+<select id="day" class="day-selector">
+<option value="lundi">Lundi</option>
+<option value="mardi">Mardi</option>
+<option value="mercredi">Mercredi</option>
+<option value="jeudi">Jeudi</option>
+<option value="vendredi">Vendredi</option>
+<option value="samedi">Samedi</option>
+<option value="dimanche">Dimanche</option>
+</select>
+<div>
+<label>Exercice</label>
+<input type="text" id="exerciseName" />
+<label>Séries</label>
+<input type="number" id="series" />
+<label>Répétitions</label>
+<input type="number" id="reps" />
+<label>Poids (kg)</label>
+<input type="number" id="weight" />
+<label>Repos (sec)</label>
+<input type="number" id="rest" />
+<button id="addExercise">Ajouter</button>
+</div>
+<div class="list" id="exerciseList"></div>
+<button id="save">Sauvegarder</button>
+<button id="export">Exporter en PDF</button>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script>
+const daySelect = document.getElementById('day');
+const list = document.getElementById('exerciseList');
+new Sortable(list, { animation: 150, onSort: save });
+function load() {
+ const data = localStorage.getItem(daySelect.value);
+ list.innerHTML = '';
+ if (data) JSON.parse(data).forEach(addItemToDOM);
+}
+function addItemToDOM(item) {
+ const div = document.createElement('div');
+ div.className = 'exercise';
+ div.innerText = `${item.name} - ${item.series}x${item.reps} ${item.weight}kg, repos ${item.rest}s`;
+ div.dataset.json = JSON.stringify(item);
+ list.appendChild(div);
+}
+function save() {
+ const items = [...list.children].map(div => JSON.parse(div.dataset.json));
+ localStorage.setItem(daySelect.value, JSON.stringify(items));
+}
+document.getElementById('addExercise').onclick = () => {
+ const item = {
+   name: document.getElementById('exerciseName').value,
+   series: document.getElementById('series').value,
+   reps: document.getElementById('reps').value,
+   weight: document.getElementById('weight').value,
+   rest: document.getElementById('rest').value
+ };
+ addItemToDOM(item);
+ save();
+};
+
+document.getElementById('save').onclick = save;
+
+document.getElementById('export').onclick = () => {
+ const { jsPDF } = window.jspdf;
+ const doc = new jsPDF();
+ doc.text(`Programme du ${daySelect.value}`, 10, 10);
+ [...list.children].forEach((div, i) => {
+   doc.text(`${i+1}. ${div.innerText}`, 10, 20 + i*10);
+ });
+ doc.save(`programme-${daySelect.value}.pdf`);
+};
+
+daySelect.onchange = load;
+load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide a simple workout planner in `index.html`
- allow reordering exercises with SortableJS
- update README with usage instructions
- mention HTML linting using tidy
- apply modern styling and fix export code

## Testing
- `tidy -e index.html`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840b453513c8326b0778201f0ba9631