### PR TITLE
Implement progression tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ tidy -e index.html
 - Calcul des besoins caloriques via le BMR en fonction de l'âge, de la taille, du sexe, du poids et de l'activité
 - Interface modernisée avec Tailwind CSS et arrière-plan animé
 - Footer fournissant un lien vers le dépôt Git
+- Suivi de la progression des charges pour chaque exercice
+- Fenêtres intégrées pour modifier un exercice et consulter l'historique

--- a/index.html
+++ b/index.html
@@ -46,6 +46,8 @@ body {
   cursor:pointer;
   transition:color .3s;
 }
+#modal { display:none; }
+#modal.show { display:flex; }
 </style>
 </head>
 <body>
@@ -111,9 +113,12 @@ body {
 <div id="calories" class="text-center"></div>
 </div>
 <button id="export" class="mt-4 bg-gray-900 text-white px-4 py-2 rounded transition hover:bg-gray-700">Exporter en PDF</button>
-<footer class="text-center text-gray-500 mt-8">
-  <p>Code source sur <a href="https://github.com/user/repo" class="underline">GitHub</a></p>
-</footer>
+  <footer class="text-center text-gray-500 mt-8">
+    <p>Code source sur <a href="https://github.com/user/repo" class="underline">GitHub</a></p>
+  </footer>
+</div>
+<div id="modal" class="fixed inset-0 bg-black/50 hidden items-center justify-center">
+  <div id="modalBox" class="bg-white p-4 rounded shadow w-80"></div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="jspdf.plugin.autotable.js"></script>
@@ -129,6 +134,21 @@ const weightInput = document.getElementById('currentWeightInput');
 const activityInput = document.getElementById('activity');
 const caloriesDiv = document.getElementById('calories');
 const dayCells = document.querySelectorAll('#dayTable td');
+const modal = document.getElementById('modal');
+const modalBox = document.getElementById('modalBox');
+
+function showModal(content) {
+  modalBox.innerHTML = content;
+  modal.classList.remove('hidden');
+  modal.classList.add('show');
+}
+
+function closeModal() {
+  modal.classList.add('hidden');
+  modal.classList.remove('show');
+}
+
+modal.onclick = e => { if (e.target === modal) closeModal(); };
 
 function getMacros(weight, goal) {
   const ref = {
@@ -188,7 +208,15 @@ function load() {
  const data = localStorage.getItem(daySelect.value);
  list.innerHTML = '';
  const items = data ? JSON.parse(data) : [];
- items.forEach(addItemToDOM);
+ let modified = false;
+ items.forEach(it => {
+   if (!it.history) {
+     it.history = [{ date: new Date().toLocaleDateString('fr-CA'), weight: it.weight }];
+     modified = true;
+   }
+   addItemToDOM(it);
+ });
+ if (modified) localStorage.setItem(daySelect.value, JSON.stringify(items));
  header.classList.toggle('hidden', items.length === 0);
  updateNumbers();
 }
@@ -205,6 +233,7 @@ function addItemToDOM(item) {
   const actions = document.createElement('div');
   actions.className = 'flex gap-1';
   const toggle = document.createElement('button');
+  const historyBtn = document.createElement('button');
   const edit = document.createElement('button');
   const remove = document.createElement('button');
 
@@ -226,22 +255,53 @@ function addItemToDOM(item) {
     save();
   };
 
+  historyBtn.className = 'history ml-2 text-gray-500 hover:text-gray-800';
+  historyBtn.textContent = '📈';
+  historyBtn.onclick = () => {
+    const lines = item.history.map(h => `<li>${h.date} : ${h.weight}kg</li>`).join('');
+    showModal(`<div><h3 class='font-semibold mb-2'>Historique</h3><ul class='list-disc pl-4'>${lines || '<li>Aucune donnée</li>'}</ul><div class='text-right mt-2'><button id='closeHist' class='px-2 py-1 bg-blue-600 text-white rounded'>Fermer</button></div></div>`);
+    document.getElementById('closeHist').onclick = closeModal;
+  };
+
   edit.className = 'edit ml-2 text-gray-500 hover:text-gray-800';
   edit.textContent = '✎';
   edit.onclick = () => {
-    const n = prompt('Exercice', item.name);
-    const s = prompt('Séries', item.series);
-    const rps = prompt('Répétitions', item.reps);
-    const w = prompt('Poids (kg)', item.weight);
-    const r = prompt('Repos (sec)', item.rest);
-    if (n) item.name = n;
-    if (s) item.series = s;
-    if (rps) item.reps = rps;
-    if (w) item.weight = w;
-    if (r) item.rest = r;
-    updateText();
-    div.dataset.json = JSON.stringify(item);
-    save();
+    showModal(`<div class='space-y-2'>
+      <label>Exercice</label>
+      <input id='editName' class='border rounded w-full p-1' value='${item.name}'>
+      <label>Séries</label>
+      <input id='editSeries' class='border rounded w-full p-1' type='number' value='${item.series}'>
+      <label>Répétitions</label>
+      <input id='editReps' class='border rounded w-full p-1' type='number' value='${item.reps}'>
+      <label>Poids (kg)</label>
+      <input id='editWeight' class='border rounded w-full p-1' type='number' value='${item.weight}'>
+      <label>Repos (sec)</label>
+      <input id='editRest' class='border rounded w-full p-1' type='number' value='${item.rest}'>
+      <div class='text-right space-x-2'>
+        <button id='cancelEdit' class='px-2 py-1 bg-gray-300 rounded'>Annuler</button>
+        <button id='saveEdit' class='px-2 py-1 bg-blue-600 text-white rounded'>OK</button>
+      </div>
+    </div>`);
+    document.getElementById('cancelEdit').onclick = closeModal;
+    document.getElementById('saveEdit').onclick = () => {
+      const n = document.getElementById('editName').value;
+      const s = document.getElementById('editSeries').value;
+      const rps = document.getElementById('editReps').value;
+      const w = document.getElementById('editWeight').value;
+      const r = document.getElementById('editRest').value;
+      item.name = n;
+      item.series = s;
+      item.reps = rps;
+      if (w && w !== item.weight) {
+        item.weight = w;
+        item.history.push({ date: new Date().toLocaleDateString('fr-CA'), weight: w });
+      }
+      item.rest = r;
+      updateText();
+      div.dataset.json = JSON.stringify(item);
+      save();
+      closeModal();
+    };
   };
 
   remove.className = 'delete ml-2 text-gray-500 hover:text-gray-800';
@@ -252,7 +312,7 @@ function addItemToDOM(item) {
     save();
   };
 
-  actions.append(toggle, edit, remove);
+  actions.append(toggle, historyBtn, edit, remove);
   div.append(num, nameSpan, seriesSpan, repsSpan, weightSpan, restSpan, actions);
   div.dataset.json = JSON.stringify(item);
   list.appendChild(div);
@@ -319,7 +379,8 @@ document.getElementById('addExercise').onclick = () => {
    reps: document.getElementById('reps').value,
    weight: document.getElementById('weight').value,
    rest: document.getElementById('rest').value,
-   success: false
+   success: false,
+   history: [{ date: new Date().toLocaleDateString('fr-CA'), weight: document.getElementById('weight').value }]
 };
  addItemToDOM(item);
  save();


### PR DESCRIPTION
## Summary
- keep a history of the weight used for each exercise
- show a small progression window per exercise
- preserve existing entries when loading old data
- document the new progression feature
- nicer inline modal for editing and history

## Testing
- `tidy -e index.html`


------
https://chatgpt.com/codex/tasks/task_e_68441017cd008326987859341f7c7f82